### PR TITLE
fix: Add unistd.h to avoid build errors.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libqapt (3.0.5.2-deepin2) unstable; urgency=medium
+
+  * Add unistd.h to avoid build errors on aarch64 architecture.
+    - Add patch 0003-add-unistd-header-fix-arm64-error.patch
+
+ -- renbin <renbin@uniontech.com>  Mon, 23 Oct 2023 16:36:14 +0800
+
 libqapt (3.0.5.1-1-deepin1) unstable; urgency=medium
 
   * New version 3.0.5.1-1-deepin1

--- a/debian/patches/0003-add-unistd-header-fix-arm64-error.patch
+++ b/debian/patches/0003-add-unistd-header-fix-arm64-error.patch
@@ -1,0 +1,32 @@
+Description: Add unistd.h avoid build errors. 
+ Function in unistd.h not found on aarch64
+ architecture. Add unistd.h to help find functions.
+Forwarded: not-needed
+Last-Update: 2023-10-23
+---
+
+ src/worker/aptlock.cpp   |    2 ++
+ src/worker/aptworker.cpp |    1 +
+ 2 files changed, 3 insertions(+)
+
+--- a/src/worker/aptlock.cpp
++++ b/src/worker/aptlock.cpp
+@@ -23,6 +23,8 @@
+ #include <apt-pkg/error.h>
+ #include <QDebug>
+ 
++#include <unistd.h>
++
+ AptLock::AptLock(const QString &path)
+     : m_path(path.toUtf8())
+     , m_fd(-1)
+--- a/src/worker/aptworker.cpp
++++ b/src/worker/aptworker.cpp
+@@ -43,6 +43,7 @@
+ #include <apt-pkg/upgrade.h>
+ #include <apt-pkg/versionmatch.h>
+ #include <string>
++#include <unistd.h>
+ 
+ // System includes
+ #include <sys/statvfs.h>

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 0001-add-zh_CN-translate.patch
 0002-add-interface-get-provides-version.patch
+0003-add-unistd-header-fix-arm64-error.patch


### PR DESCRIPTION
* Add unistd.h to avoid build errors on aarch64 architecture.
  - Add patch 0003-add-unistd-header-fix-arm64-error.patch

Log: Add unistd.h to avoid build errors.