### PR TITLE
fix: sync long description patch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libqapt (3.0.5.3-deepin1) unstable; urgency=medium
+
+  * fix: sync long description patch
+    - Add patch 0004-fix-long-description-error.patch
+
+ -- renbin <renbin@uniontech.com>  Tue, 10 Dec 2024 13:04:28 +0800
+
 libqapt (3.0.5.2-deepin2) unstable; urgency=medium
 
   * Add unistd.h to avoid build errors on aarch64 architecture.

--- a/debian/patches/0004-fix-long-description-error.patch
+++ b/debian/patches/0004-fix-long-description-error.patch
@@ -1,0 +1,71 @@
+Description: fix description error.
+ Improved the function to get package descriptions,
+ and fixed the way to get the long/short description.
+Bug: PMS-290525
+Forwarded: no-needed
+Author: Pino Toscano <zs@deepin.com>
+Last-Update: 2024-12-10
+
+--- a/src/debfile.cpp
++++ b/src/debfile.cpp
+@@ -24,6 +24,7 @@
+ #include <QProcess>
+ #include <QStringBuilder>
+ #include <QTemporaryFile>
++#include <QtCore/QRegularExpression>
+ 
+ // Must be before APT_PKG_ABI checks!
+ #include <apt-pkg/macros.h>
+@@ -150,39 +151,26 @@
+ 
+ QString DebFile::longDescription() const
+ {
+-    QString rawDescription = QLatin1String(d->controlData->FindS("Description").c_str());
+-    // Remove short description
+-    rawDescription.remove(shortDescription() + '\n');
+-
++    QString rawDescription = QString(d->controlData->FindS("Description").c_str());
+     QString parsedDescription;
+     // Split at double newline, by "section"
+-    QStringList sections = rawDescription.split(QLatin1String("\n ."));
++    const QStringList sections = rawDescription.split("\n ");
++
++    // starts from 1, pass short description.
++    for (int i = 1; i < sections.count(); ++i)
++        parsedDescription.append(sections[i]);
++    parsedDescription.replace(QRegularExpression("[\r\n]+", QRegularExpression::MultilineOption), "\n");
++
++    if (!parsedDescription.isEmpty())
++        return parsedDescription;
++    else
++        return shortDescription();
+ 
+-    for (int i = 0; i < sections.count(); ++i) {
+-        sections[i].replace(QRegExp(QLatin1String("\n( |\t)+(-|\\*)")),
+-                                QLatin1String("\n\r ") % QString::fromUtf8("\xE2\x80\xA2"));
+-        // There should be no new lines within a section.
+-        sections[i].remove(QLatin1Char('\n'));
+-        // Hack to get the lists working again.
+-        sections[i].replace(QLatin1Char('\r'), QLatin1Char('\n'));
+-        // Merge multiple whitespace chars into one
+-        sections[i].replace(QRegExp(QLatin1String("\\ \\ +")), QChar::fromLatin1(' '));
+-        // Remove the initial whitespace
+-        sections[i].remove(0, 1);
+-        // Append to parsedDescription
+-        if (sections[i].startsWith(QLatin1String("\n ") % QString::fromUtf8("\xE2\x80\xA2 ")) || !i) {
+-            parsedDescription += sections[i];
+-        }  else {
+-            parsedDescription += QLatin1String("\n\n") % sections[i];
+-        }
+-    }
+-    return parsedDescription;
+ }
+ 
+ QString DebFile::shortDescription() const
+ {
+-    QString longDesc = QLatin1String(d->controlData->FindS("Description").c_str());
+-
++    QString longDesc(d->controlData->FindS("Description").c_str());
+     return longDesc.left(longDesc.indexOf(QLatin1Char('\n')));
+ }
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 0001-add-zh_CN-translate.patch
 0002-add-interface-get-provides-version.patch
 0003-add-unistd-header-fix-arm64-error.patch
+0004-fix-long-description-error.patch


### PR DESCRIPTION
Sync patch, fix the long description incorrect.

Log: Fix long description incorrect.
Bug: PMS-290525